### PR TITLE
minor changes in the sample code

### DIFF
--- a/sample/HelloWorldPanel.hx
+++ b/sample/HelloWorldPanel.hx
@@ -12,6 +12,6 @@ class HelloWorldPanel extends Panel {
         var col = layout.column();
         col.label("Hello, world!");
         col.label("What is your name?");
-        col.prop(Context.scene, "my_name");
+        col.prop(context.scene, "my_name");
     }
 }

--- a/sample/Main.hx
+++ b/sample/Main.hx
@@ -19,7 +19,6 @@ import blender.bpy.props.StringProperty;
 })
 class Main {
     public static function main() {
-        register();
     }
 
     public static function register():Void {

--- a/src/blender/bpy/Utils.hx
+++ b/src/blender/bpy/Utils.hx
@@ -1,6 +1,5 @@
 package blender.bpy;
 
-import blender.bpy.types.Panel;
 import blender.bpy.types.typeargs.PathType;
 
 /**
@@ -10,7 +9,7 @@ import blender.bpy.types.typeargs.PathType;
 extern class Utils {
     /**
        Returns a list of paths to external files referenced by the loaded .blend file.
-       @param absolute When true the paths returned are made absolute. 
+       @param absolute When true the paths returned are made absolute.
        @param packed When true skip file paths for packed data.
        @param local When true skip linked library paths.
        @return Array<String>
@@ -46,7 +45,7 @@ extern class Utils {
        Unload the python class from blender.
 
        If the class has an unregister class method it will be called before unregistering.
-       @param cls - 
+       @param cls -
      */
     public static function unregister_class(cls:Class<Dynamic>):Void;
 


### PR DESCRIPTION
- `Context.scene` isn't static so i guess it should have been `context.scene`
- calling `register()` in main failed in blender 2.79 as the initialization macro already calls `register()`
- removed an unused import b/c vscode complained
